### PR TITLE
Provide fallback `inputSchema` where there's none

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ export async function startServer() {
   const tools = await getToolsFromActions(integrationKey)
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: tools.filter((tool) => tool.inputSchema),
+    tools,
   }))
 
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
@@ -87,7 +87,10 @@ export async function getToolsFromActions(integrationKey: string): Promise<Tool[
     tools.push({
       name: action.key,
       description: action.name,
-      inputSchema: action.inputSchema as any,
+      inputSchema: (action.inputSchema as Tool['inputSchema']) || {
+        type: 'object',
+        properties: undefined,
+      },
     })
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ export async function startServer() {
   const tools = await getToolsFromActions(integrationKey)
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools,
+    tools: tools.filter((tool) => tool.inputSchema),
   }))
 
   server.setRequestHandler(CallToolRequestSchema, async (request) => {


### PR DESCRIPTION
### Description

Fixes an issue where tools fail to load when one or more of them have inputSchema set to undefined.

Per the [type definition for inputSchema](https://github.com/modelcontextprotocol/typescript-sdk/blob/75ec9de108afdc1728a305d1c1b36278df601270/src/types.ts#L737), its value must not be undefined. To address this, we set the properties field of inputSchema to undefined instead of assigning undefined to inputSchema itself.