### PR TITLE
feat: add `integrationKey` query to filter connections by integration

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -71,9 +71,11 @@ async function addServerTool({
 
 // Factory to create a new McpServer with tools from all integrations
 async function createMcpServer({
-  token
+  token,
+  integrationKey
 }: {
   token: string;
+  integrationKey?: string 
 }) {
   console.log('Creating MCP server instance...');
   
@@ -82,7 +84,9 @@ async function createMcpServer({
   });
 
   console.log('Fetching connections...');
-  const connections = await membrane.connections.find();
+  const connections = await membrane.connections.find(integrationKey ? {
+    integrationKey
+  } : {});
   console.log(`Found ${connections.items.length} connections`);
 
   const server = new McpServer({
@@ -175,6 +179,7 @@ app.all('/mcp', async (req, res) => {
 app.get('/sse', async (req, res) => {
     console.log('Received SSE connection request');
     const token = req.query.token as string;
+    const integrationKey = req.query.integrationKey as string | undefined;
 
     if (!token) {
         console.log('SSE request missing token');
@@ -196,7 +201,8 @@ app.get('/sse', async (req, res) => {
       console.log('Creating new server instance for SSE connection');
       // Create a new server instance per connection
       const server = await createMcpServer({
-        token
+        token,
+        integrationKey
       });
       console.log('Connecting to transport...');
       await server.connect(transport);


### PR DESCRIPTION
### Description

By default, the MCP server exposes all action instances for a customer as tools. This PR introduces a `?integrationKey` query so you can get tools for specific apps. This is useful when you need to gradually expose tools to your LLM

### Usage Example

```js
import { experimental_createMCPClient } from 'ai';

const integrationAppCustomerAcessToken = ""
const filterByIntegrationKey = "hubspot"

 const url = `{SERVER_URL}/sse?token=${integrationAppCustomerAcessToken}?integrationKey={filterByIntegrationKey}`
 
   const mcpClient = await experimental_createMCPClient({
    transport: {
      type: 'sse',
      url,
    },
  });
  
 const tools = await mcpClient.tools(); // only hubspot tools
```