### PR TITLE
fix: Patch possibly missing array item type

### DIFF
--- a/src/server/utils/json-schema-to-zod.ts
+++ b/src/server/utils/json-schema-to-zod.ts
@@ -26,7 +26,10 @@ function zodTypeFromJsonSchema(schema: any): ZodTypeAny {
     case 'boolean':
       return z.boolean();
     case 'array':
-      return z.array(zodTypeFromJsonSchema(schema.items));
+      return z.array(
+        // membrane may not have an items field on array types, let's default to string
+        schema.items ? zodTypeFromJsonSchema(schema.items) : z.string()
+      );
     case 'object': {
       const shape: ZodRawShape = {};
       const props = schema.properties || {};


### PR DESCRIPTION
### Description

When add tool to the server, the action input schema from membrane may contain array fields that do not have a type, this include a path for fall back to `z.string()` and not `z.any()` in those cases. 

### Why

LLM would fail when listing tools if a tool has a parameter schema where fields contain array with items type `z.any()`

<img width="876" alt="Screenshot 2025-06-18 at 12 20 08" src="https://github.com/user-attachments/assets/13cce815-e700-4d2d-a247-c5ac8fae4956" />
